### PR TITLE
add failing async test

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -30,6 +30,23 @@ tape('through', function (t) {
   )
 })
 
+tape('through async', function (t) {
+  pull(
+    pull.values([1,2,3]),
+    through(function (data) {
+      var self = this
+      setTimeout(function () {
+        self.queue(data * 10)
+      }, 10)
+    }),
+    pull.collect(function (err, ary) {
+      if(err) throw err
+      t.deepEqual(ary, [10, 20, 30])
+      t.end()
+    })
+  )
+})
+
 tape('through + end', function (t) {
   pull(
     pull.values([1,2,3]),


### PR DESCRIPTION
I've been trying to use this module with async work, but if all emits are async this breaks down. Added a failing test to show the behaviour I mean.

This fails with


```
# through async
not ok 3 should be equivalent
  ---
    operator: deepEqual
    expected: [ 10, 20, 30 ]
    actual:   []
    at: pull (/Users/dignifiedquire/opensource/pull-through/index.js:46:22)
  ...
```
